### PR TITLE
Support for advanced VC hierarchy and rotation bug

### DIFF
--- a/RDVTabBarController/RDVTabBarController.m
+++ b/RDVTabBarController/RDVTabBarController.m
@@ -174,6 +174,10 @@
     
     _tabBarHidden = hidden;
     
+    // Unhiding is done at once
+    if (!hidden)
+        [self.tabBar setHidden:NO];
+
     void (^block)() = ^{
         CGSize viewSize = self.view.frame.size;
         CGRect contentViewFrame = [[self contentView] frame];
@@ -207,9 +211,15 @@
     if (animated) {
         [UIView animateWithDuration:0.24 animations:^{
             block();
+        } completion:^(BOOL finished) {
+            // Cannot add this to a block, that way bar is hidden at once
+            if (hidden)
+                [self.tabBar setHidden:YES];
         }];
     } else {
         block();
+        if (hidden)
+            [self.tabBar setHidden:YES];
     }
 }
 


### PR DESCRIPTION
Commits address two issues:
- When rotating hidden tab bar it is shown as it is right below window's view.
- Putting something else instead of a navigation controller into tabs breaks accessing `tabBarController` from a category. For me this was required when each tab became a container view controller for banner advertising.
