### PR TITLE
fixed content view height calculation

### DIFF
--- a/RDVTabBarController/RDVTabBarController.m
+++ b/RDVTabBarController/RDVTabBarController.m
@@ -61,7 +61,7 @@
     
     if (![self isTabBarHidden]) {
         tabBarStartingY = viewSize.height - tabBarHeight;
-        contentViewHeight = viewSize.height - [[self tabBar] minimumContentHeight];
+        contentViewHeight = viewSize.height - tabBarHeight;
     }
     
     [[self tabBar] setFrame:CGRectMake(0, tabBarStartingY, viewSize.width, tabBarHeight)];


### PR DESCRIPTION
If the itemHeight is not set for any of the tabbar items, using the tabbar's minimumContentHeight leads to a wrong contentView height.
