### PR TITLE
Fixed bug : When badge number is zero, RDVTabBarItem also displays the i...

### DIFF
--- a/RDVTabBarController/RDVTabBarItem.m
+++ b/RDVTabBarController/RDVTabBarItem.m
@@ -181,7 +181,7 @@
     
     // Draw badges
     
-    if ([[self badgeValue] length]) {
+    if ([[self badgeValue] integerValue] != 0) {
         CGSize badgeSize = CGSizeZero;
         
         if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1) {


### PR DESCRIPTION
Fixed bug : When badge number is zero, RDVTabBarItem also displays the invalid information.