### PR TITLE
When setting new TabBar items, remove previous ones first.

### DIFF
--- a/RDVTabBarController/RDVTabBar.m
+++ b/RDVTabBarController/RDVTabBar.m
@@ -99,15 +99,18 @@
 }
 
 - (void)setItems:(NSArray *)items {
-    for (RDVTabBarItem *item in items) {
-        [item removeFromSuperview];
-    }
+  for (id subview in self.subviews) {
+    if ([subview isKindOfClass:[RDVTabBarItem class]])
+      [subview removeFromSuperview];
+  }
+  
+  [items makeObjectsPerformSelector:@selector(removeFromSuperview)];
     
-    _items = [items copy];
-    for (RDVTabBarItem *item in items) {
-        [item addTarget:self action:@selector(tabBarItemWasSelected:) forControlEvents:UIControlEventTouchDown];
-        [self addSubview:item];
-    }
+  _items = [items copy];
+  for (RDVTabBarItem *item in items) {
+    [item addTarget:self action:@selector(tabBarItemWasSelected:) forControlEvents:UIControlEventTouchDown];
+    [self addSubview:item];
+  }
 }
 
 - (void)setHeight:(CGFloat)height {


### PR DESCRIPTION
Inactive `viewControllers` of my RDVTabBarController subclass get purged when memory is low. And so as its  TabBarItem objects. The problem when reestablishing again those controllers is that the TabBar items of the purged VCs are still out there on the TabBar, resulting in duplicate tabs. When I checked the setter method of RDVTabBar's item property, it only assumes the same items are being sent over when in fact they're not.
