### PR TITLE
pass through preferredStatusBarStyle and preferredStatusBarUpdateAnimation requests

### DIFF
--- a/RDVTabBarController/RDVTabBarController.m
+++ b/RDVTabBarController/RDVTabBarController.m
@@ -118,6 +118,8 @@
     [[[self selectedViewController] view] setFrame:[[self contentView] bounds]];
     [[self contentView] addSubview:[[self selectedViewController] view]];
     [[self selectedViewController] didMoveToParentViewController:self];
+    
+    [self setNeedsStatusBarAppearanceUpdate];
 }
 
 - (void)setViewControllers:(NSArray *)viewControllers {


### PR DESCRIPTION
Without these lines of code, the tab bar viewControllers cannot change the status bar style as easily - their preferredStatusBarStyle would never be called!

I have been looking for the reason of this weird behaviour for almost an hour =)

I hope this saves someone else some time :)
