### PR TITLE
Fix app crashing when applying auto layout on tabbaritems.

### DIFF
--- a/RDVTabBarController/RDVTabBar.m
+++ b/RDVTabBarController/RDVTabBar.m
@@ -61,32 +61,35 @@
 }
 
 - (void)layoutSubviews {
-    CGSize frameSize = self.frame.size;
-    CGFloat minimumContentHeight = [self minimumContentHeight];
-    
-    [[self backgroundView] setFrame:CGRectMake(0, frameSize.height - minimumContentHeight,
-                                            frameSize.width, frameSize.height)];
-    
-    [self setItemWidth:roundf((frameSize.width - [self contentEdgeInsets].left -
-                               [self contentEdgeInsets].right) / [[self items] count])];
-    
-    NSInteger index = 0;
-    
-    // Layout items
-    
-    for (RDVTabBarItem *item in [self items]) {
-        CGFloat itemHeight = [item itemHeight];
+    // Is it exist Autolayout??
+    if (self.translatesAutoresizingMaskIntoConstraints) {
+        CGSize frameSize = self.frame.size;
+        CGFloat minimumContentHeight = [self minimumContentHeight];
         
-        if (!itemHeight) {
-            itemHeight = frameSize.height;
+        [[self backgroundView] setFrame:CGRectMake(0, frameSize.height - minimumContentHeight,
+                                                   frameSize.width, frameSize.height)];
+        
+        [self setItemWidth:roundf((frameSize.width - [self contentEdgeInsets].left -
+                                   [self contentEdgeInsets].right) / [[self items] count])];
+        
+        NSInteger index = 0;
+        
+        // Layout items
+        
+        for (RDVTabBarItem *item in [self items]) {
+            CGFloat itemHeight = [item itemHeight];
+            
+            if (!itemHeight) {
+                itemHeight = frameSize.height;
+            }
+            
+            [item setFrame:CGRectMake(self.contentEdgeInsets.left + (index * self.itemWidth),
+                                      roundf(frameSize.height - itemHeight) - self.contentEdgeInsets.top,
+                                      self.itemWidth, itemHeight - self.contentEdgeInsets.bottom)];
+            [item setNeedsDisplay];
+            
+            index++;
         }
-        
-        [item setFrame:CGRectMake(self.contentEdgeInsets.left + (index * self.itemWidth),
-                                  roundf(frameSize.height - itemHeight) - self.contentEdgeInsets.top,
-                                  self.itemWidth, itemHeight - self.contentEdgeInsets.bottom)];
-        [item setNeedsDisplay];
-        
-        index++;
     }
     
     [super layoutSubviews];


### PR DESCRIPTION
On iOS below 8 (7.1;7.0;Sim or Real device), app will crash and prompt to call [super layoutSubviews]
**\* Assertion failure in -[RDVAppTabBar layoutSublayersOfLayer:], /SourceCache/UIKit_Sim/UIKit-2935.137/UIView.m:8794
**\* Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Auto Layout still required after executing -layoutSubviews. RDVAppTabBar's implementation of -layoutSubviews needs to call super.'

p.s. This fix will not affect non-autolayout view's display.
