### PR TITLE
Modified indexForViewController to accomodate tabbar in navigationViewController

### DIFF
--- a/RDVTabBarController/RDVTabBarController.m
+++ b/RDVTabBarController/RDVTabBarController.m
@@ -155,8 +155,8 @@
 
 - (NSInteger)indexForViewController:(UIViewController *)viewController {
     UIViewController *searchedController = viewController;
-    if ([searchedController navigationController]) {
-        searchedController = [searchedController navigationController];
+    while (searchedController.parentViewController != nil && searchedController.parentViewController != self) {
+        searchedController = searchedController.parentViewController;
     }
     return [[self viewControllers] indexOfObject:searchedController];
 }


### PR DESCRIPTION
The current implementation of indexForViewController in RDVTabBarController.m does not cover the case where the tabbarcontroller is inside a navigationbarcontroller. As such, when you search for the navigation controller of the searched controller, you are returning the parent navigation controller which is not in the NSArray of viewcontrollers in the tab bar. 

By making sure that the parentviewcontroller is not nill and that it is not self, you can avoid this case.
