### PR TITLE
Fix an orientation bug

### DIFF
--- a/RDVTabBarController/RDVTabBarController.m
+++ b/RDVTabBarController/RDVTabBarController.m
@@ -57,6 +57,11 @@
     
     [self setTabBarHidden:self.isTabBarHidden animated:NO];
 }
+-(void)viewDidLayoutSubviews{
+    [super viewDidLayoutSubviews];
+    [self setTabBarHidden:self.isTabBarHidden animated:NO];
+
+}
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
     return self.selectedViewController.preferredStatusBarStyle;


### PR DESCRIPTION
Fix an orientation bug

Fix an orientation bug 

when rdv  have an orientation event or change the frame , _contentView will extend to the buttom... Please see the image...
http://7u2sco.com1.z0.glb.clouddn.com/3B479F46-2593-44A4-9009-13A9FF44B16E.png
