### PR TITLE
Added alignment style for tab bar item title

### DIFF
--- a/RDVTabBarController/RDVTabBarItem.h
+++ b/RDVTabBarController/RDVTabBarItem.h
@@ -23,6 +23,11 @@
 
 #import <UIKit/UIKit.h>
 
+typedef NS_ENUM(NSUInteger, RDVTabBarItemTitleVericalAlignment) {
+    RDVTabBarItemTitleVericalAlignmentIconBottom,
+    RDVTabBarItemTitleVericalAlignmentViewBottom
+};
+
 @interface RDVTabBarItem : UIControl
 
 /**
@@ -56,6 +61,11 @@
  * The title attributes dictionary used for tab bar item's selected state.
  */
 @property (copy) NSDictionary *selectedTitleAttributes;
+
+/*
+ * The alignment for title label
+ */
+@property (assign) RDVTabBarItemTitleVericalAlignment titleAlignment;
 
 #pragma mark - Image configuration
 

--- a/RDVTabBarController/RDVTabBarItem.m
+++ b/RDVTabBarController/RDVTabBarItem.m
@@ -66,6 +66,7 @@
     
     _title = @"";
     _titlePositionAdjustment = UIOffsetZero;
+    _titleAlignment = RDVTabBarItemTitleVericalAlignmentIconBottom;
     
     if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1) {
         _unselectedTitleAttributes = @{
@@ -96,7 +97,8 @@
     UIImage *backgroundImage = nil;
     UIImage *image = nil;
     CGFloat imageStartingY = 0.0f;
-    
+    CGFloat titleStartingY = 0.0f;
+
     if ([self isSelected]) {
         image = [self selectedImage];
         backgroundImage = [self selectedBackgroundImage];
@@ -143,9 +145,25 @@
             
             CGContextSetFillColorWithColor(context, [titleAttributes[NSForegroundColorAttributeName] CGColor]);
             
+            switch (self.titleAlignment) {
+                case RDVTabBarItemTitleVericalAlignmentIconBottom: {
+                    titleStartingY = imageStartingY + imageSize.height + _titlePositionAdjustment.vertical;
+                    break;
+                }
+                case RDVTabBarItemTitleVericalAlignmentViewBottom: {
+                    static const CGFloat titleBottomOffset = 5.;
+                    titleStartingY = frameSize.height - titleSize.height - titleBottomOffset;
+                    break;
+                }
+                default: {
+                    titleStartingY = imageStartingY + imageSize.height + _titlePositionAdjustment.vertical;
+                    break;
+                }
+            }
+            
             [_title drawInRect:CGRectMake(roundf(frameSize.width / 2 - titleSize.width / 2) +
                                           _titlePositionAdjustment.horizontal,
-                                          imageStartingY + imageSize.height + _titlePositionAdjustment.vertical,
+                                          titleStartingY,
                                           titleSize.width, titleSize.height)
                 withAttributes:titleAttributes];
         } else {


### PR DESCRIPTION
Current implementation produce wry text alignment on tab bar item if given images different sizes, like this 

![screen shot 2015-06-18 at 8 09 13 pm](https://cloud.githubusercontent.com/assets/9250530/8237416/d04a39e4-15f7-11e5-9bea-de5d27bbc1b4.png)

Implemented alignment style - so it's possible to draw text in old way right under image, and draw title above view bottom.