### PR TITLE
Fix layout issues by reorganizing layout code

### DIFF
--- a/Example/Classes/App Delegate/RDVAppDelegate.m
+++ b/Example/Classes/App Delegate/RDVAppDelegate.m
@@ -46,15 +46,15 @@
 #pragma mark - Methods
 
 - (void)setupViewControllers {
-    UIViewController *firstViewController = [[RDVFirstViewController alloc] init];
+    UIViewController *firstViewController = [[RDVFirstViewController alloc] initWithNibName:nil bundle:nil];
     UIViewController *firstNavigationController = [[UINavigationController alloc]
                                                    initWithRootViewController:firstViewController];
     
-    UIViewController *secondViewController = [[RDVSecondViewController alloc] init];
+    UIViewController *secondViewController = [[RDVSecondViewController alloc] initWithNibName:nil bundle:nil];
     UIViewController *secondNavigationController = [[UINavigationController alloc]
                                                     initWithRootViewController:secondViewController];
     
-    UIViewController *thirdViewController = [[RDVThirdViewController alloc] init];
+    UIViewController *thirdViewController = [[RDVThirdViewController alloc] initWithNibName:nil bundle:nil];
     UIViewController *thirdNavigationController = [[UINavigationController alloc]
                                                    initWithRootViewController:thirdViewController];
     


### PR DESCRIPTION
**Commit 1:** Move all layout code to viewDidLayoutSubviews, where it belongs, and set proper autoresizing masks on the content view controllers. This resolves a number of problems:
1. The initially selected view controller was being resized to a zero size on viewWillAppear
2. If a view controller didn't already happen to have an autoresizing mask set, it would never be resized after its tab got selected. In particular, it would not adjust to rotations or in-call status bar, and, in the most degenerate case, it would stay at zero size if the problem #1 caused it to be resized to zero.
3. The animations are now run by invoking layoutIfNeeded, which should allow animated resizing of autolayout-based content in the tabs. (Didn't actually test this one, but it makes sense.)

In general, by performing the layout during the layout cycle, we can be sure that things are layed out properly in all cases without any timing issues. This also eliminates edge triggering in `setTabBarHidden:animated:`, together with weird calls to that method from unexpected places like `viewWillAppear:`.

**Commit 2:** Fix invocations of unavailable convenience initializers on the example view controllers.

Because `initWithNibName:bundle:` was never invoked, the titles were missing and the table rows said `(null)`.

Note: this supersedes #65.
